### PR TITLE
Make Log Groups Input Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudwatch_filter_pattern"></a> [cloudwatch\_filter\_pattern](#input\_cloudwatch\_filter\_pattern) | A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events. | `string` | `""` | no |
-| <a name="input_cloudwatch_log_group_names"></a> [cloudwatch\_log\_group\_names](#input\_cloudwatch\_log\_group\_names) | List of CloudWatch Log Group names to stream logs from. | `list(string)` | n/a | yes |
+| <a name="input_cloudwatch_log_group_names"></a> [cloudwatch\_log\_group\_names](#input\_cloudwatch\_log\_group\_names) | List of CloudWatch Log Group names to stream logs from. | `list(string)` | n/a | no |
 | <a name="input_destination_bucket_arn"></a> [destination\_bucket\_arn](#input\_destination\_bucket\_arn) | ARN of the bucket for CloudWatch filters. | `string` | `""` | no |
 | <a name="input_destination_http_endpoint"></a> [destination\_http\_endpoint](#input\_destination\_http\_endpoint) | HTTP endpoint for CloudWatch filters. | `string` | `""` | no |
 | <a name="input_s3_compression_format"></a> [s3\_compression\_format](#input\_s3\_compression\_format) | Allow optional configuration of AWS Data Stream compression. Log Group subscription filters compress logs by default. | `string` | `"UNCOMPRESSED"` | no |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudwatch_filter_pattern"></a> [cloudwatch\_filter\_pattern](#input\_cloudwatch\_filter\_pattern) | A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events. | `string` | `""` | no |
-| <a name="input_cloudwatch_log_group_names"></a> [cloudwatch\_log\_group\_names](#input\_cloudwatch\_log\_group\_names) | List of CloudWatch Log Group names to stream logs from. | `list(string)` | n/a | no |
+| <a name="input_cloudwatch_log_group_names"></a> [cloudwatch\_log\_group\_names](#input\_cloudwatch\_log\_group\_names) | List of CloudWatch Log Group names to stream logs from. | `list(string)` | `[]` | no |
 | <a name="input_destination_bucket_arn"></a> [destination\_bucket\_arn](#input\_destination\_bucket\_arn) | ARN of the bucket for CloudWatch filters. | `string` | `""` | no |
 | <a name="input_destination_http_endpoint"></a> [destination\_http\_endpoint](#input\_destination\_http\_endpoint) | HTTP endpoint for CloudWatch filters. | `string` | `""` | no |
 | <a name="input_s3_compression_format"></a> [s3\_compression\_format](#input\_s3\_compression\_format) | Allow optional configuration of AWS Data Stream compression. Log Group subscription filters compress logs by default. | `string` | `"UNCOMPRESSED"` | no |

--- a/main.tf
+++ b/main.tf
@@ -188,8 +188,9 @@ resource "aws_cloudwatch_log_stream" "firehose" {
 }
 
 # Cloudwatch Log Subscription Filters to stream logs from specified log groups to Firehose
+# IF no log groups are provided during mod call, no subscription filters are created
 resource "aws_cloudwatch_log_subscription_filter" "cloudwatch-to-firehose" {
-  count           = length(var.cloudwatch_log_group_names)
+  count           = length(var.cloudwatch_log_group_names) > 0 ? length(var.cloudwatch_log_group_names) : 0
   destination_arn = aws_kinesis_firehose_delivery_stream.firehose.arn
   filter_pattern  = var.cloudwatch_filter_pattern
   log_group_name  = element(var.cloudwatch_log_group_names, count.index)

--- a/variables.tf
+++ b/variables.tf
@@ -8,9 +8,13 @@ variable "cloudwatch_filter_pattern" {
   default     = ""
 }
 
+# NOTE: this variable deals with single and multiple log groups at the time of TF apply
+# Do not provide this input if the resource sending logs to XSIAM Cortex generates continuous log groups
+# Instead, create subscription filters directly from the resource or module that generates the log groups
 variable "cloudwatch_log_group_names" {
   type        = list(string)
   description = "List of CloudWatch Log Group names to stream logs from."
+  default     = []
 }
 
 variable "destination_bucket_arn" {


### PR DESCRIPTION
This makes the cloudwatch log groups an optional input. Which is useful when trying to send logs from a resource to XSIAM, that generates continuous log groups (as opposed to one or multiple at apply that contain all the required streams). This allows for no log groups to be provided, so that the sub filters can be created directly from the module (for example RDS etc).